### PR TITLE
商品一覧表示機能 #6

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new
@@ -17,6 +18,11 @@ class ItemsController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order(created_at: :desc)
-    # @items = []
+
   end
 
   def new
@@ -15,13 +15,12 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path, notice: '商品を出品しました。'
     else
-      # バリデーション失敗時に new を描き直して、エラーメッセージを表示
       render :new, status: :unprocessable_entity
     end
   end
 
   def show
-    @item = Item.find(params[:id])
+    # @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,8 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order(created_at: :desc)
-    #@items = []
-
+    # @items = []
   end
 
   def new
@@ -24,7 +23,6 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,8 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.all.order(created_at: :desc)
+    #@items = []
+
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,59 +123,67 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <div class="subtitle" >
+    <div class="subtitle">
       新規投稿商品
     </div>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% if @items.present? %>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to item_path(item) do %>
+              <div class='item-img-content'>
+                <%# 商品に画像があればそれを表示、なければサンプル画像 %>
+                <% if item.image.attached? %>
+                  <%= image_tag item.image, class: "item-img" %>
+                <% else %>
+                  <%= image_tag "item-sample.png", class: "item-img" %>
+                <% end %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+                <%# 商品が売れていればsold outを表示しましょう（purchase_record がある前提なら） %>
+                <%# if item.purchase_record.present? %>
+                <%#   <div class='sold-out'>
+                <%#     <span>Sold Out!!</span>
+                <%#   </div> %>
+                <%# end %>
+              </div>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  <%= item.item_name %>
+                </h3>
+                <div class='item-price'>
+                  <span><%= item.price %>円<br><%= '配送料負担' %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </li>
         <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% else %>
+        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,10 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to item_path(item) do %>
+            <%= link_to "#" do %> 
               <div class='item-img-content'>
                 <%# 商品に画像があればそれを表示、なければサンプル画像 %>
                 <% if item.image.attached? %>
@@ -154,7 +153,7 @@
                   <%= item.item_name %>
                 </h3>
                 <div class='item-price'>
-                  <span><%= item.price %>円<br><%= '配送料負担' %></span>
+                  <span><%= item.price %>円<br><%= "配送料負担：#{item.delivery_cost.name}" %></span>
                   <div class='star-btn'>
                     <%= image_tag "star.png", class:"star-icon" %>
                     <span class='star-count'>0</span>
@@ -164,8 +163,8 @@
             <% end %>
           </li>
         <% end %>
-      <% else %>
-        <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <%# <% else %> 
+ 
         <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -184,8 +183,7 @@
           <% end %>
         </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+ 
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
 
    get 'items/new', to: 'items#new'
 
-   resources :items, only: [:index, :new, :create]
+   resources :items, only: [:index, :new, :create, :show]
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
 
    get 'items/new', to: 'items#new'
 
-   resources :items, only: [:index, :new, :create, :show]
+   resources :items, only: [:index, :new, :create]
 
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -95,11 +95,10 @@ RSpec.describe Item, type: :model do
       end
 
       it 'user が紐付いていないと保存できないこと' do
-      item.user = nil
-      item.valid?
-      expect(item.errors.full_messages).to include('User must exist')
+        item.user = nil
+        item.valid?
+        expect(item.errors.full_messages).to include('User must exist')
       end
-
     end
   end
 
@@ -140,7 +139,5 @@ RSpec.describe Item, type: :model do
         %w[--- 1〜2日で発送 2〜3日で発送 4〜7日で発送]
       )
     end
-
-
   end
 end


### PR DESCRIPTION
# What
ユーザー管理、商品出品機能に続き商品一覧表示機能を実装する。
# Why
これまでユーザー管理、商品出品機能により、ユーザーに紐づいた商品データを取得可能となり、これを表示する機能を実装する。

# プルリクエストへ記載するgyazo
https://gyazo.com/009419ebd0bdbd2e7b4ed7c74c3d21dc
## 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/e3e34cceb2f72cadc4a5d0ac6fa578d8
## 商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）